### PR TITLE
Allow for definition of custom ingress / egress gateways

### DIFF
--- a/charts/install_smcp_with_helm/control-plane/egress.yaml
+++ b/charts/install_smcp_with_helm/control-plane/egress.yaml
@@ -1,0 +1,2 @@
+enabled: true
+service: {}

--- a/charts/install_smcp_with_helm/control-plane/ingress.yaml
+++ b/charts/install_smcp_with_helm/control-plane/ingress.yaml
@@ -1,0 +1,2 @@
+enabled: true
+service: {}

--- a/charts/install_smcp_with_helm/control-plane/templates/servicemeshcontrolplane-basic-install.yaml
+++ b/charts/install_smcp_with_helm/control-plane/templates/servicemeshcontrolplane-basic-install.yaml
@@ -58,14 +58,14 @@ spec:
               targetPort: 15443
           type: ClusterIP
     egress:
-{{- if .Vaules.smcp_enable_custom_egress_config }}
+{{- if .Values.smcp_enable_custom_egress_config }}
 {{ .Files.Get smcp_custom_egress_config_file | indent 6 }}
 {{- else }}
       enabled: false
       service: {}
 {{- end }}
     ingress:
-{{- if .Vaules.smcp_enable_custom_ingress_config }}
+{{- if .Values.smcp_enable_custom_ingress_config }}
 {{ .Files.Get smcp_custom_ingress_config_file | indent 6 }}
 {{- else }}
       enabled: false

--- a/charts/install_smcp_with_helm/control-plane/templates/servicemeshcontrolplane-basic-install.yaml
+++ b/charts/install_smcp_with_helm/control-plane/templates/servicemeshcontrolplane-basic-install.yaml
@@ -58,11 +58,19 @@ spec:
               targetPort: 15443
           type: ClusterIP
     egress:
+{{- if .Vaules.smcp_enable_custom_egress_config }}
+{{ .Files.Get smcp_custom_egress_config_file | indent 6 }}
+{{- else }}
       enabled: false
       service: {}
+{{- end }}
     ingress:
+{{- if .Vaules.smcp_enable_custom_ingress_config }}
+{{ .Files.Get smcp_custom_ingress_config_file | indent 6 }}
+{{- else }}
       enabled: false
       service: {}
+{{- end }}
   addons:
     grafana:
       enabled: true

--- a/charts/install_smcp_with_helm/control-plane/values.yaml
+++ b/charts/install_smcp_with_helm/control-plane/values.yaml
@@ -12,6 +12,7 @@ smcp_runtime_kiali_cpu_requests: 100m
 smcp_runtime_kiali_memory_requests: 128Mi
 smcp_runtime_tracing_jaeger_cpu_requests: 100m
 smcp_runtime_tracing_jaeger_memory_requests: 128Mi
-
-
-
+smcp_enable_custom_ingress_config: false
+smcp_enable_custom_egress_config: false
+smcp_custom_ingress_config_file: "ingress.yaml"
+smcp_custom_egress_config_file: "egress.yaml"


### PR DESCRIPTION
This MR allows the user to create custom ingress and egress gateway definitions in the ingress.yaml and egress.yaml files, then enable them on the SMCP object being deployed by toggling the appropriate values in the values.yaml file.